### PR TITLE
Add actual GameBoy camera resolution 128x112

### DIFF
--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -2,6 +2,7 @@
 <resources>
 	<string name="pref_resolution_default">320x200</string>
     <string-array name="pref_resolution_labels">
+	    <item>128x112</item>
 	    <item>160x120</item>
 	    <item>256x224</item>
 	    <item>320x200</item>
@@ -10,6 +11,7 @@
         <item>960x720</item>
 	</string-array>
     <string-array name="pref_resolution_values">
+        <item>128x112</item>
         <item>160x120</item>
 		<item>256x224</item>
         <item>320x200</item>


### PR DESCRIPTION
See https://en.wikipedia.org/wiki/Game_Boy_Camera.

(I also notice a discrepancy between label and value for `480x320` vs. `480x360`, but I don't know which was intended)